### PR TITLE
make changes to sync with TreeMaker upgrades

### DIFF
--- a/BuildFile.xml
+++ b/BuildFile.xml
@@ -11,6 +11,6 @@
 <use name="fastjet"/>
 <use name="ktjet"/>
 <use name="CommonTools/UtilAlgos"/>
-<use name="AllHadronicSUSY/Products"/>
+<use name="TreeMaker/Products"/>
 
 <flags   EDM_PLUGIN="1"/>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ setenv SCRAM_ARCH slc6_amd64_gcc491
 cmsrel CMSSW_7_2_3_patch1
 cd CMSSW_7_2_3_patch1/src
 cmsenv
-git clone git@github.com:awhitbeck/TreeMaker.git -b CMSSW_7_2_X .
+git clone git@github.com:awhitbeck/TreeMaker.git -b Run2
 git clone git@github.com:awhitbeck/SuSySubstructure.git -b synch_June26_2015 AWhitbeck/SuSySubstructure
 cd AWhitbeck/SuSySubstructure
 ./retrieveFastJetTools.sh

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ setenv SCRAM_ARCH slc6_amd64_gcc491
 cmsrel CMSSW_7_2_3_patch1
 cd CMSSW_7_2_3_patch1/src
 cmsenv
-git clone git@github.com:awhitbeck/TreeMaker.git -b Run2
-git clone git@github.com:awhitbeck/SuSySubstructure.git -b synch_June26_2015 AWhitbeck/SuSySubstructure
+git clone git@github.com:TreeMaker/TreeMaker.git -b Run2
+git clone git@github.com:awhitbeck/SuSySubstructure.git -b Run2 AWhitbeck/SuSySubstructure
 cd AWhitbeck/SuSySubstructure
 ./retrieveFastJetTools.sh
 cd ../../

--- a/python/fatJetStudies_cff.py
+++ b/python/fatJetStudies_cff.py
@@ -26,13 +26,8 @@ def fatJetSetup( process ):
                                              ptCut = cms.untracked.double(50.0),
                                              debug = cms.untracked.bool(False)
                                              )
-
-    process.ak1p2Jets4Vec = cms.EDProducer("fourVectorProducer",
-                                           particleCollection = cms.untracked.InputTag("ak1p2Jets"),
-                                           debug = cms.untracked.bool(False)
-                                           )
     
-    process.TreeMaker2.VectorTLorentzVector.append("ak1p2Jets4Vec(ak1p2Jets)")
+    process.TreeMaker2.VectorRecoCand.append("ak1p2Jets")
     process.TreeMaker2.VarsDouble.append("ak1p2sumJetMass(ak1p2Jets_sumJetMass)")
 
     # nsubjettiness stuff
@@ -69,12 +64,7 @@ def fatJetSetup( process ):
                                                    debug = cms.untracked.bool(False)
                                                    )
     
-    process.ak1p2JetsNoTrim4Vec = cms.EDProducer("fourVectorProducer",
-                                                 particleCollection = cms.untracked.InputTag("ak1p2JetsNoTrim"),
-                                                 debug = cms.untracked.bool(False)
-                                                 )
-
-    #process.TreeMaker2.VectorTLorentzVector.append("ak1p2JetsNoTrim4Vec(ak1p2JetsNoTrim)")
+    #process.TreeMaker2.VectorRecoCand.append("ak1p2JetsNoTrim")
     #process.TreeMaker2.VarsDouble.append("ak1p2NoTrimSumJetMass(ak1p2JetsNoTrim_sumJetMass)")
 
     #reclustered ak12 jets
@@ -127,13 +117,13 @@ def fatJetSetup( process ):
                                       process.ak1p2Jets * 
                                       process.ak1p2sumJetMass * 
                                       process.nSubjettiness *
-                                      process.ak1p2Jets4Vec *
                                       #process.ak1p2JetsNoTrim *
                                       #process.ak1p2NoTrimSumJetMass * 
-                                      #process.ak1p2JetsNoTrim4Vec *
                                       process.slimmedJetsPt15 * 
                                       process.fattenedJetsPt30 * 
                                       process.fattenedJetsPt20 * 
                                       process.fattenedJetsPt15 
                                       )
+
+    return process
     

--- a/test/PHYS14production.py
+++ b/test/PHYS14production.py
@@ -3,10 +3,6 @@ from commandLineParameters import *
 
 process = cms.Process("analysis")
 
-process.options = cms.untracked.PSet(
-    SkipEvent = cms.untracked.vstring('ProductNotFound')
-    )
-
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = options.reportEvery
 
@@ -18,56 +14,50 @@ process.options   = cms.untracked.PSet(
 ## configure geometry & conditions
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+##  LOAD DATAFILES
+readFiles = cms.untracked.vstring()
+
+if options.inputFilesConfig!="" :
+    process.load("AWhitbeck.SuSySubstructure."+options.inputFilesConfig+"_cff")
+    readFiles.extend( process.source.fileNames )
+
+if options.files!=[] :    
+    readFiles.extend( options.files )
 
 ###############
 # tree maker
 ###############
 
-from AllHadronicSUSY.TreeMaker.makeTreeFromMiniAOD_cff import makeTreeFromMiniAOD
-makeTreeFromMiniAOD(process,
-                    outFileName="ReducedSelection",
-                    reportEveryEvt=options.reportEvery,
-                    testFileName="",
-                    Global_Tag="PHYS14_25_V2::All",
-                    Global_Tag="GR_P_V56::All",
-                    lostlepton=True,
-                    hadtau=True,
+from TreeMaker.TreeMaker.makeTreeFromMiniAOD_cff import makeTreeFromMiniAOD
+process = makeTreeFromMiniAOD(process,
+                    outfile=options.outputFile+"_RA2AnalysisTree",
+                    reportfreq=options.reportEvery,
+                    dataset=readFiles,
+                    globaltag="PHYS14_25_V2::All",
+                    lostlepton=False,
+                    hadtau=False,
                     tagandprobe=False,
-                    numProcessedEvt=options.numEvents,
+                    numevents=options.numEvents,
                     doZinv=True,
                     debugtracks=False,
-                    geninfo=False,
-                    tagname="RECO",
-                    jsonfile="Cert_246908-251883_13TeV_PromptReco_Collisions15_JSON.txt"
+                    geninfo=True,
+                    tagname="PAT",
+                    jsonfile="",
+                    applyjec=False
                     )
 
-# drop all recoCand stuff and replace with 4-vectors
-# --------------------------------------------------
-process.TreeMaker2.VarsRecoCand = []
+## CONFIGURE TFILESERVICE
 
-process.goodElectrons4Vec = cms.EDProducer("fourVectorProducer",
-                                           particleCollection = cms.untracked.InputTag("LeptonsNew","IdIsoElectron"),
-                                           debug = cms.untracked.bool(False)
-                                           )
-
-process.goodMuons4Vec = cms.EDProducer("fourVectorProducer",
-                                           particleCollection = cms.untracked.InputTag("LeptonsNew","IdIsoMuon"),
-                                           debug = cms.untracked.bool(False)
-                                           )
-
-process.TreeMaker2.VectorTLorentzVector.append("goodMuons4Vec(Muons)")
-process.TreeMaker2.VectorInt.append("LeptonsNew:MuonCharge(MuonCharge)")
-process.TreeMaker2.VectorTLorentzVector.append("goodElectrons4Vec(Electrons)")
-process.TreeMaker2.VectorInt.append("LeptonsNew:ElectronCharge(ElectronCharge)")
+process.TFileService.closeFileFast = cms.untracked.bool(True)
 
 ##################################
 # DEFINE MODULES FOR ANALYSIS
 ##################################
 
-###############
+# ==================
 # rho stuff
-###############
+# ==================
 
 process.TreeMaker2.VarsDouble.append("fixedGridRhoFastjetAll(rho)")
 
@@ -76,24 +66,15 @@ process.TreeMaker2.VarsDouble.append("fixedGridRhoFastjetAll(rho)")
 # ==================
 
 #from AWhitbeck.SuSySubstructure.fatJetStudies_cff import *
-#fatJetSetup(process) ## define relevant modules and a sequence to be used, process.SumJetMass
+#process = fatJetSetup(process) ## define relevant modules and a sequence to be used, process.SumJetMass
+#process.AdditionalSequence += process.SumJetMass ## add process.SumJetMass to sequence
 
 # ==================
 # ak4 jets
 # ==================
 
-process.ak4Jets = cms.EDProducer("fourVectorProducer",
-                                   particleCollection = cms.untracked.InputTag("GoodJets"),
-                                   debug = cms.untracked.bool(False)
-                                   )
-
-process.ak4JetsRaw = cms.EDProducer("fourVectorProducer",
-                                    particleCollection = cms.untracked.InputTag("slimmedJets"),
-                                    debug = cms.untracked.bool(False)
-                                    )
-
-process.TreeMaker2.VectorTLorentzVector.append("ak4Jets")
-process.TreeMaker2.VectorTLorentzVector.append("ak4JetsRaw")
+process.TreeMaker2.VectorRecoCand.append("GoodJets(ak4Jets)")
+process.TreeMaker2.VectorRecoCand.append("slimmedJets(ak4JetsRaw)")
 #process.TreeMaker2.VectorInt.append("GoodJets:passJetID(ak4Jets_passedJetID)")
 
 process.TreeMaker2.VectorDouble.append("JetsProperties:bDiscriminatorUser(ak4Jets_CSVdisc)")
@@ -112,74 +93,4 @@ process.TreeMaker2.VectorInt.append("JetsProperties:photonMultiplicity(ak4Jets_p
 process.TreeMaker2.VectorInt.append("JetsProperties:flavor(ak4Jets_flavor)")
 
 ### ak4 gen jets
-#process.ak4GenJets = cms.EDProducer("fourVectorProducer",
-#                                   particleCollection = cms.untracked.InputTag("slimmedGenJets"),
-#                                   debug = cms.untracked.bool(False)
-#                                   )
-
-#process.TreeMaker2.VectorTLorentzVector.append("ak4GenJets")
-
-######################
-# event filters
-######################
-
-process.RA2eventFilter = cms.EDFilter("RA2eventFilter",
-                                      HTCollection = cms.untracked.InputTag("htNoPhotons"),
-                                      minHT = cms.untracked.double(500.),
-                                      MHTCollection = cms.untracked.InputTag("mhtNoPhotons"),
-                                      minMHT = cms.untracked.double(200.),
-                                      NJetsCollection = cms.untracked.InputTag("nJetsNoPhotons"),
-#                                      minNJets = cms.untracked.int(4),
-                                      BTagsCollection = cms.untracked.InputTag("BTags"),
-#                                      minBTags = cms.untracked.int(0),
-                                      minDeltaPhiNCollection = cms.untracked.InputTag("metNoPhotons","minDeltaPhiN"),
-                                      debug = cms.untracked.bool(False)
-                                      )
-
-## CONFIGURE TFILESERVICE
-
-process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string(options.outputFile+"_RA2AnalysisTree.root"),
-                                   closeFileFast = cms.untracked.bool(True)
-                                   )
-
-##  LOAD DATAFILES
-if options.inputFilesConfig!="" :
-    process.load("AWhitbeck.SuSySubstructure."+options.inputFilesConfig+"_cff")
-
-if options.files!=[] :   
-    readFiles = cms.untracked.vstring()
-    readFiles.extend( options.files )
-    process.source = cms.Source("PoolSource",
-                                fileNames = readFiles )
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(options.numEvents)
-)
-
-##  DEFINE SCHEDULE
-
-process.WriteTree = cms.Path( process.Baseline * 
-                              process.AdditionalSequence *
-                              process.goodElectrons4Vec * 
-                              process.goodMuons4Vec *  
-
-                              process.ak4Jets *
-                              process.ak4JetsRaw *
-                              #process.ak4GenJets *
-
-                              #process.SumJetMass * 
-                              
-                              process.TreeMaker2 
-                              )
-
-#OUPUT CONFIGURATION
-#process.out = cms.OutputModule("PoolOutputModule",
-#                               fileName = cms.untracked.string('test.root'),
-#                               #save only events passing the full path
-#                               #SelectEvents = cms.untracked.PSet( SelectEvents = cms.vstring('p') ),
-#                               outputCommands = cms.untracked.vstring('drop *','keep *_*photon*_*_*','keep *_*Jets*_*_*'
-#                                                                      )
-#                               )
-
-#process.outpath = cms.EndPath(process.out)
+#process.TreeMaker2.VectorRecoCand.append("slimmedGenJets(ak4GenJets)")

--- a/test/PHYS14production.py
+++ b/test/PHYS14production.py
@@ -4,12 +4,6 @@ from commandLineParameters import *
 process = cms.Process("analysis")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = options.reportEvery
-
-process.options   = cms.untracked.PSet(
-    SkipEvent   = cms.untracked.vstring('ProductNotFound'),
-    wantSummary = cms.untracked.bool(True)
-    )
 
 ## configure geometry & conditions
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
@@ -35,8 +29,8 @@ process = makeTreeFromMiniAOD(process,
                     reportfreq=options.reportEvery,
                     dataset=readFiles,
                     globaltag="PHYS14_25_V2::All",
-                    lostlepton=False,
-                    hadtau=False,
+                    lostlepton=True,
+                    hadtau=True,
                     tagandprobe=False,
                     numevents=options.numEvents,
                     doZinv=True,
@@ -46,6 +40,11 @@ process = makeTreeFromMiniAOD(process,
                     jsonfile="",
                     applyjec=False
                     )
+
+process.options   = cms.untracked.PSet(
+    SkipEvent   = cms.untracked.vstring('ProductNotFound'),
+    wantSummary = cms.untracked.bool(True)
+    )
 
 ## CONFIGURE TFILESERVICE
 
@@ -73,24 +72,24 @@ process.TreeMaker2.VarsDouble.append("fixedGridRhoFastjetAll(rho)")
 # ak4 jets
 # ==================
 
-process.TreeMaker2.VectorRecoCand.append("GoodJets(ak4Jets)")
-process.TreeMaker2.VectorRecoCand.append("slimmedJets(ak4JetsRaw)")
+#process.TreeMaker2.VectorRecoCand.append("GoodJets(ak4Jets)")
+#process.TreeMaker2.VectorRecoCand.append("slimmedJets(ak4JetsRaw)")
 #process.TreeMaker2.VectorInt.append("GoodJets:passJetID(ak4Jets_passedJetID)")
 
-process.TreeMaker2.VectorDouble.append("JetsProperties:bDiscriminatorUser(ak4Jets_CSVdisc)")
-process.TreeMaker2.VectorDouble.append("JetsProperties:bDiscriminatorMVA(ak4Jets_MVAdisc)")
+#process.TreeMaker2.VectorDouble.append("JetsProperties:bDiscriminatorUser(ak4Jets_CSVdisc)")
+#process.TreeMaker2.VectorDouble.append("JetsProperties:bDiscriminatorMVA(ak4Jets_MVAdisc)")
 #process.TreeMaker2.VectorDouble.append("JetsProperties:bDiscriminatorSimpleCSV(ak4Jets_SimpleCSVdisc)")
 
 #process.TreeMaker2.VectorInt.append("JetsProperties:NumBhadrons(ak4Jets_NumBhadrons)")
 #process.TreeMaker2.VectorInt.append("JetsProperties:NumChadrons(ak4Jets_NumChadrons)")
 
-process.TreeMaker2.VectorDouble.append("JetsProperties:chargedHadronEnergyFraction(ak4Jets_chargeHadEfrac)")
-process.TreeMaker2.VectorDouble.append("JetsProperties:neutralHadronEnergyFraction(ak4Jets_neutralHadEfrac)")
-process.TreeMaker2.VectorDouble.append("JetsProperties:photonEnergyFraction(ak4Jets_photonEfrac)")
-process.TreeMaker2.VectorInt.append("JetsProperties:chargedHadronMultiplicity(ak4Jets_chargedHadMult)")
-process.TreeMaker2.VectorInt.append("JetsProperties:neutralHadronMultiplicity(ak4Jets_neutralHadMult)")
-process.TreeMaker2.VectorInt.append("JetsProperties:photonMultiplicity(ak4Jets_photonMult)")
-process.TreeMaker2.VectorInt.append("JetsProperties:flavor(ak4Jets_flavor)")
+#process.TreeMaker2.VectorDouble.append("JetsProperties:chargedHadronEnergyFraction(ak4Jets_chargeHadEfrac)")
+#process.TreeMaker2.VectorDouble.append("JetsProperties:neutralHadronEnergyFraction(ak4Jets_neutralHadEfrac)")
+#process.TreeMaker2.VectorDouble.append("JetsProperties:photonEnergyFraction(ak4Jets_photonEfrac)")
+#process.TreeMaker2.VectorInt.append("JetsProperties:chargedHadronMultiplicity(ak4Jets_chargedHadMult)")
+#process.TreeMaker2.VectorInt.append("JetsProperties:neutralHadronMultiplicity(ak4Jets_neutralHadMult)")
+#process.TreeMaker2.VectorInt.append("JetsProperties:photonMultiplicity(ak4Jets_photonMult)")
+#process.TreeMaker2.VectorInt.append("JetsProperties:flavor(ak4Jets_flavor)")
 
 ### ak4 gen jets
 #process.TreeMaker2.VectorRecoCand.append("slimmedGenJets(ak4GenJets)")


### PR DESCRIPTION
Things we should discuss before merging this PR:
- I'm letting makeTreeFromMiniAOD do most of the process management now (input source, TFileService, etc.)
- I set lostlepton=False by default. It adds a ton of branches to the tree; previously we were getting rid of them all by dropping the RecoCands, but now we don't want to do that. Is anyone who does lost lepton stuff going to be using our trees?
- I noticed that JetsProperties only runs on HTJets, but we store the variables as though they correspond to ak4jets = GoodJets. We could add a line to PHYS14production.py to change which collection is used by JetsProperties, or make a separate version of it...

In general, look it over and let me know if I removed/changed anything that you want to keep as it was...
